### PR TITLE
feat: faster rounding with bitwise and operation

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -206,21 +206,13 @@ pub fn format_duration(duration: std::time::Duration) -> String {
 /// round-half-up behaviour. I had tried using math::round::half_to_even, but that didn't seem to
 /// work correctly (rounded 42.55 to 42).
 pub fn bankers_rounding(float: f64) -> u32 {
-    let fractional_part = float - float.floor();
     let rounded_down = float as u32;
-    if fractional_part < 0.5 {
-        return rounded_down;
-    } else if fractional_part > 0.5 {
-        return rounded_down + 1;
-    } else {  // fractional_part == 0.5
-        if rounded_down % 2 == 0 {  // is even
-            return rounded_down;
-        } else {
-            return rounded_down + 1;
-        }
+    match float.fract() {
+        f if f < 0.5 => rounded_down,
+        f if f > 0.5 => rounded_down + 1,
+        _ => rounded_down + (rounded_down & 1),
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -214,6 +214,7 @@ pub fn bankers_rounding(float: f64) -> u32 {
     }
 }
 
+
 #[cfg(test)]
 mod tests {
     use flate2::Compression;


### PR DESCRIPTION
This PR replaces the current modulo by 2 operation with a bitwise operation. We `and` the truncated number with 1 which yields 1 if odd, 0 otherwise. Then we immediately add it to the truncated number.