### PR TITLE
feat: use bitwsise xor operations for getting orientation

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -271,7 +271,7 @@ fn get_orientation(a_1: &Alignment, a_2: &Alignment) -> Orientation {
     // Get the read start positions, which is the ref-end position if on the negative strand.
     let a_1_pos = if a_1.is_on_forward_strand() { a_1.ref_start } else { a_1.get_ref_end() };
     let a_2_pos = if a_2.is_on_forward_strand() { a_2.ref_start } else { a_2.get_ref_end() };
-    let cmp = (a_1_pos > a_2_pos) as u8;
+    let cmp = (a_1_pos >= a_2_pos) as u8;
     let mask = (cmp << 1) + cmp;
     let orientation = (((a_1.is_on_forward_strand() as u8) << 1) + a_2.is_on_forward_strand() as u8) ^ mask;
     orientation.into()
@@ -315,7 +315,7 @@ fn auto_determine_orientation(insert_sizes: &InsertSizes) -> Orientation {
     } else {
         quit_with_error("Error: could not automatically determine read pair orientation");
     }
-    Orientation::Auto  // unreachable
+    unreachable!()
 }
 
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -194,10 +194,10 @@ pub enum Orientation {
 
 impl Orientation {
     const VARIANTS: [Orientation; 4] = [
-        Orientation::ReverseReverse,
-        Orientation::ReverseForward,
         Orientation::ForwardReverse,
+        Orientation::ReverseForward,
         Orientation::ForwardForward,
+        Orientation::ReverseReverse,
     ];
 }
 
@@ -221,7 +221,6 @@ impl ToString for Orientation {
             Self::ForwardReverse => "fr",
             Self::ForwardForward => "ff",
             Self::Auto => "auto"
-            
         };
         repr.into()
     }
@@ -296,8 +295,9 @@ fn determine_correct_orientation(correct_orientation: Orientation,
     }
     if correct_orientation == Orientation::Auto {
         let auto_orientation = auto_determine_orientation(insert_sizes);
-        eprintln!("\nAutomatically determined correct orientation: {}\n", auto_orientation);
-        Orientation::Auto
+        eprintln!("\nAutomatically determined correct orientation: {}\n",
+                  auto_orientation.to_string());
+        auto_orientation
     } else {
         eprintln!("\nUser-specified correct orientation: {}\n", correct_orientation.to_string());
         correct_orientation
@@ -305,18 +305,17 @@ fn determine_correct_orientation(correct_orientation: Orientation,
 }
 
 
-fn auto_determine_orientation(insert_sizes: &InsertSizes) -> String {
+fn auto_determine_orientation(insert_sizes: &InsertSizes) -> Orientation {
     let max_count = insert_sizes.iter().map(|v| v.len()).max().unwrap_or(0);
     let orientations: Vec<Orientation> = Orientation::VARIANTS.into_iter()
         .filter(|&orientation| insert_sizes[orientation].len() == max_count)
         .collect();
-    let mut best_orientation = String::new();
     if orientations.len() == 1 {
-        best_orientation = orientations[0].to_string();
+        return orientations[0];
     } else {
         quit_with_error("Error: could not automatically determine read pair orientation");
     }
-    best_orientation
+    Orientation::Auto  // unreachable
 }
 
 
@@ -504,28 +503,28 @@ mod tests {
         insert_sizes[Orientation::ReverseForward].extend_from_slice(&[200]);
         insert_sizes[Orientation::ForwardForward].extend_from_slice(&[300]);
         insert_sizes[Orientation::ReverseReverse].extend_from_slice(&[400]);
-        assert_eq!(auto_determine_orientation(&insert_sizes), "fr");
+        assert_eq!(auto_determine_orientation(&insert_sizes).to_string(), "fr");
 
         let mut insert_sizes = InsertSizes::new();
         insert_sizes[Orientation::ForwardReverse].extend_from_slice(&[100]);
         insert_sizes[Orientation::ReverseForward].extend_from_slice(&[200, 200, 200]);
         insert_sizes[Orientation::ForwardForward].extend_from_slice(&[300]);
         insert_sizes[Orientation::ReverseReverse].extend_from_slice(&[400]);
-        assert_eq!(auto_determine_orientation(&insert_sizes), "rf");
+        assert_eq!(auto_determine_orientation(&insert_sizes).to_string(), "rf");
 
         let mut insert_sizes = InsertSizes::new();
         insert_sizes[Orientation::ForwardReverse].extend_from_slice(&[100]);
         insert_sizes[Orientation::ReverseForward].extend_from_slice(&[200]);
         insert_sizes[Orientation::ForwardForward].extend_from_slice(&[300, 300, 300]);
         insert_sizes[Orientation::ReverseReverse].extend_from_slice(&[400]);
-        assert_eq!(auto_determine_orientation(&insert_sizes), "ff");
+        assert_eq!(auto_determine_orientation(&insert_sizes).to_string(), "ff");
 
         let mut insert_sizes = InsertSizes::new();
         insert_sizes[Orientation::ForwardReverse].extend_from_slice(&[100]);
         insert_sizes[Orientation::ReverseForward].extend_from_slice(&[200]);
         insert_sizes[Orientation::ForwardForward].extend_from_slice(&[300]);
         insert_sizes[Orientation::ReverseReverse].extend_from_slice(&[400, 400, 400]);
-        assert_eq!(auto_determine_orientation(&insert_sizes), "rr");
+        assert_eq!(auto_determine_orientation(&insert_sizes).to_string(), "rr");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,9 @@ mod misc;
 mod pileup;
 mod polish;
 
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 use clap::{Parser, Subcommand, crate_version};
+use filter::Orientation;
 
 
 #[derive(Parser)]
@@ -62,8 +63,8 @@ enum Commands {
         out2: PathBuf,
 
         /// Expected pair orientation
-        #[clap(long = "orientation", default_value = "auto")]
-        orientation: String,
+        #[clap(long = "orientation", default_value = "auto", value_parser = Orientation::from_str)]
+        orientation: Orientation,
 
         /// Low percentile threshold
         #[clap(long = "low", default_value = "0.1")]


### PR DESCRIPTION
### Changes
- Represent `Orientation` as enum with 4 primary variants plus an `Auto` variant
- The underlying type is a `u8` (one byte)
- Use the `u8` representation when not displaying the orientation because one byte is inexpensive
- Since a strand can be forward or reverse, we represent the boolean values as `1` and `0` (`u8`) so that we can later use them for faster bitwise operations
- The `HashMap`s with the keys of type `Orientation` are now represented as vectors with a maximum of 5 elements, each corresponding to a variant of `Orientation`